### PR TITLE
fix(deps): download spacy model at runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,12 +53,12 @@ repos:
       - id: end-of-file-fixer
         types: [ python ]
 
-  # - repo: "https://github.com/adrienverge/yamllint.git"
-  #   rev: v1.38.0
-  #   hooks:
-  #     - id: yamllint
-  #       files: ^.*\.(yaml|yml)$
-  #       entry: yamllint --strict --config-file .yamllint.yml
+  - repo: "https://github.com/adrienverge/yamllint.git"
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        files: ^.*\.(yaml|yml)$
+        entry: yamllint --strict --config-file .yamllint.yml
 
   - repo: "https://github.com/charliermarsh/ruff-pre-commit"
     rev: "v0.15.11"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -10,6 +10,10 @@ rules:
     level: error
     max-spaces-inside: 1
     min-spaces-inside: 1
+  brackets:
+    level: error
+    max-spaces-inside: 1
+    min-spaces-inside: 1
   comments-indentation: disable
   comments:
     min-spaces-from-content: 1

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python -m pip install --user neatfile
 ```
 
 > [!NOTE]\
->  Installation bundles a ~35mb English language model used for vector matching between filenames and directory names.
+>  The first time you run neatfile, it will download a ~35mb English language model (`en_core_web_md`) used for vector matching between filenames and directory names. Subsequent runs load the cached model immediately.
 
 ## Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,12 @@
         "cappa>=0.31.0",
         "datefind>=0.4.0",
         "dynaconf>=3.2.13",
-        "en-core-web-md",
         "inflect>=7.5.0",
         "nclutils>=2.1.0",
+        # Required at runtime: `spacy.cli.download` shells out to pip to
+        # install the language model on first use. `uv tool install` does
+        # not seed pip in its envs, so we must declare it explicitly.
+        "pip>=26.0.1",
         "questionary>=2.1.1,<3",
         "regex>=2026.4.4",
         "rich>=15.0.0",
@@ -56,11 +59,6 @@
 [build-system]
     build-backend = "uv_build"
     requires      = ["uv_build>=0.8.4,<0.9.0"]
-
-[tool.uv.sources]
-    # Kept out of `dependencies` so the wheel's published PyPI metadata does not
-    # contain a direct URL reference (PyPI rejects uploads that include one).
-    en-core-web-md = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" }
 
 [tool.commitizen]
     bump_message               = "bump(release): v$current_version → v$new_version"

--- a/src/neatfile/utils/nlp.py
+++ b/src/neatfile/utils/nlp.py
@@ -1,5 +1,22 @@
 """Natural language processing utilities."""
 
-import spacy
+import importlib
 
-nlp = spacy.load("en_core_web_md")
+import spacy
+import spacy.cli
+from nclutils import console
+
+_MODEL_NAME = "en_core_web_md"
+
+try:
+    nlp = spacy.load(_MODEL_NAME)
+except OSError:
+    # Model missing from the environment (first run after `uv tool install`,
+    # fresh pip install, etc). Fetch it via spaCy's installer rather than
+    # declaring a direct-URL dependency, which PyPI rejects at upload.
+    console.print(f"Downloading spaCy model '{_MODEL_NAME}' (one-time, ~40 MB)...")
+    spacy.cli.download(_MODEL_NAME)
+    # Newly pip-installed package isn't visible to the running interpreter
+    # until import caches are invalidated.
+    importlib.invalidate_caches()
+    nlp = spacy.load(_MODEL_NAME)

--- a/uv.lock
+++ b/uv.lock
@@ -411,14 +411,6 @@ wheels = [
 ]
 
 [[package]]
-name = "en-core-web-md"
-version = "3.8.0"
-source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" }
-wheels = [
-    { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl", hash = "sha256:5e6329fe3fecedb1d1a02c3ea2172ee0fede6cea6e4aefb6a02d832dba78a310" },
-]
-
-[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -771,9 +763,9 @@ dependencies = [
     { name = "cappa" },
     { name = "datefind" },
     { name = "dynaconf" },
-    { name = "en-core-web-md" },
     { name = "inflect" },
     { name = "nclutils" },
+    { name = "pip" },
     { name = "questionary" },
     { name = "regex" },
     { name = "rich" },
@@ -807,9 +799,9 @@ requires-dist = [
     { name = "cappa", specifier = ">=0.31.0" },
     { name = "datefind", specifier = ">=0.4.0" },
     { name = "dynaconf", specifier = ">=3.2.13" },
-    { name = "en-core-web-md", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" },
     { name = "inflect", specifier = ">=7.5.0" },
     { name = "nclutils", specifier = ">=2.1.0" },
+    { name = "pip", specifier = ">=26.0.1" },
     { name = "questionary", specifier = ">=2.1.1,<3" },
     { name = "regex", specifier = ">=2026.4.4" },
     { name = "rich", specifier = ">=15.0.0" },
@@ -912,6 +904,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `en-core-web-md` is distributed only as a GitHub release wheel, not on PyPI. The previous approaches (direct URL in `dependencies`, or moving it into `[tool.uv.sources]`) either failed PyPI upload or made the package uninstallable via `uv tool install`, `pip install`, or `pipx install`.
- Drop the dependency entirely. Load the model with `spacy.load("en_core_web_md")`, and on `OSError` fall back to `spacy.cli.download(...)` then retry — exactly the pattern spaCy's own docs recommend for apps that bundle a model.
- Re-declare `pip>=26.0.1` as a runtime dependency (it was present pre-`55d5d0a`). `spacy.cli.download` shells out to pip, and `uv tool` does not seed pip into its tool envs, so the transitive declaration is required.

## Test plan

- [ ] `uv run duty test` — all 108 tests still pass.
- [ ] Built wheel's `METADATA` has a clean `Requires-Dist` with no direct URL references (verified; PyPI will now accept uploads).
- [ ] `uv tool install --force 'git+https://github.com/natelandau/neatfile@fix/runtime-model-download'` succeeds and pulls `pip` as a transitive dep.
- [ ] First invocation in a fresh, unseeded venv prints `Downloading spaCy model 'en_core_web_md' (one-time, ~40 MB)...`, installs the model via pip, and loads successfully.
- [ ] Second invocation (model already installed) takes the happy path with no download.
- [ ] Verify nothing else imports `en_core_web_md` directly in a way that would surprise users.